### PR TITLE
feat: add health check for unified crawler

### DIFF
--- a/project/scrapers/unified/README.md
+++ b/project/scrapers/unified/README.md
@@ -1,21 +1,92 @@
-# 통합 Scraper
+# 통합 크롤러
 
-        /opt/crawler
-        ├─ compose.yaml # 사이트별 서비스(컨테이너) – 단일 이미지 공통 사용
-        ├─ crawl_plan.sh # 직렬 실행(순차) 배치 스크립트
-        ├─ register_cron.sh # 크론 등록 스크립트 (매일 02:00)
-        ├─ unregister_cron.sh # 크론 해제 스크립트
-        ├─ app/
-        │ ├─ Dockerfile # Playwright 베이스 이미지 사용
-        │ ├─ requirements.txt # (playwright 제외) 크롤링 라이브러리
-        │ ├─ run.py # CRAWLER_ID/NAME로 엔트리포인트 스위칭
-        │ ├─ daily_crawler.sh # 온비드 베이스→디테일 일괄 실행(어제자)
-        │ ├─ sites/
-        │ │ ├─ autoinside_daily_ec2.py # AutoInside 어제치 수집(Chromium)
-        │ │ └─ autohub_daily_ec2.py # AutoHub 어제치 수집(Chromium)
-        │ └─ onbid/
-        │ ├─ crawl_base.py # 온비드 목록 수집(requests/bs4)
-        │ └─ crawl_detail.py # 온비드 상세 수집(Firefox)
-        └─ data/ # (선택) 호스트 마운트 경로
-        ├─ onbid/base/
-        └─ onbid/result/
+EC2에서 여러 사이트 크롤러를 하나의 이미지로 실행하기 위한 디렉터리입니다.
+`CRAWLER_NAME` 환경변수에 따라 실행할 스크립트를 전환합니다.
+
+## 구조
+
+```
+/opt/crawler
+├─ compose.yaml       # 사이트별 서비스 정의 (단일 이미지 공유)
+├─ crawl_plan.sh      # 서비스를 순차 실행하는 배치 스크립트
+├─ register_cron.sh   # 크론 등록 스크립트 (매일 02:00)
+├─ unregister_cron.sh # 크론 해제 스크립트
+└─ app/
+   ├─ Dockerfile      # Playwright 기반 이미지
+   ├─ requirements.txt# 크롤링 라이브러리 (playwright 제외)
+   ├─ run.py          # CRAWLER_NAME으로 엔트리 포인트 전환
+   ├─ daily_crawler.sh# 온비드 베이스 → 디테일 일괄 실행
+   ├─ sites/
+   │  ├─ autoinside_daily_ec2.py
+   │  ├─ autohub_daily_ec2.py
+   │  └─ automart_daily_ec2.py
+   └─ onbid/
+      ├─ crawl_base.py
+      └─ crawl_detail.py
+```
+
+## 사용 방법
+
+### 이미지 빌드
+
+```bash
+docker build -t crawler app
+```
+
+### 개별 크롤러 실행
+
+`compose.yaml`에서 각 서비스는 `CRAWLER_NAME`을 전달하여 단일 이미지를 재사용합니다.
+직접 실행할 경우 다음과 같이 지정합니다.
+
+```bash
+CRAWLER_NAME=autoinside docker compose run --rm autoinside
+```
+
+### 배치 실행
+
+`crawl_plan.sh`는 `docker compose run`을 이용해 모든 서비스를 순차 실행하고
+로그를 `/var/log/<서비스명>` 디렉터리에 저장합니다.
+`register_cron.sh`를 통해 매일 02:00에 실행하도록 크론에 등록할 수 있습니다.
+
+## 헬스체크
+
+컨테이너는 `/health` 엔드포인트를 통해 동작 여부를 노출합니다.
+`compose.yaml`에는 이를 주기적으로 확인하는 `healthcheck`가 정의돼 있습니다.
+
+`run.py`에서 헬스 서버를 구동하는 코드:
+
+```python
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+
+class HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+def start_health_server():
+    HTTPServer(("0.0.0.0", 8080), HealthHandler).serve_forever()
+
+threading.Thread(target=start_health_server, daemon=True).start()
+```
+
+`compose.yaml`의 각 서비스에는 다음과 같은 설정이 포함됩니다:
+
+```yaml
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
+```
+
+`curl http://localhost:8080/health`로 수동 점검할 수 있으며,
+헬스체크 실패 시 Docker의 재시작 정책을 통해 자동 복구할 수 있습니다.
+

--- a/project/scrapers/unified/app/Dockerfile
+++ b/project/scrapers/unified/app/Dockerfile
@@ -8,6 +8,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # 브라우저 설치
 RUN playwright install chromium firefox
 
+# 헬스체크를 위한 curl 설치
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # 앱 소스 복사
 COPY run.py ./
 COPY daily_crawler.sh ./
@@ -20,5 +23,7 @@ RUN chmod +x /app/daily_crawler.sh
 # 로그/데이터 디렉토리
 RUN mkdir -p /logs /data /app/base /app/result
 ENV TZ=Asia/Seoul
+
+EXPOSE 8080
 
 ENTRYPOINT ["python", "-u", "run.py"]

--- a/project/scrapers/unified/app/run.py
+++ b/project/scrapers/unified/app/run.py
@@ -1,9 +1,28 @@
 import os
 import subprocess
 import sys
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def start_health_server():
+    HTTPServer(("0.0.0.0", 8080), HealthHandler).serve_forever()
 
 
 def main():
+    threading.Thread(target=start_health_server, daemon=True).start()
+
     crawler_name = os.environ.get("CRAWLER_NAME")
     if not crawler_name:
         print("[ERROR] CRAWLER_NAME environment variable not set.", file=sys.stderr)

--- a/project/scrapers/unified/compose.yaml
+++ b/project/scrapers/unified/compose.yaml
@@ -2,6 +2,13 @@ services:
   autoinside:
     image: crawler:latest
     container_name: crawler-autoinside
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       CRAWLER_ID: "autoinside"
       CRAWLER_NAME: "autoinside"
@@ -19,6 +26,13 @@ services:
   autohub:
     image: crawler:latest
     container_name: crawler-autohub
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       CRAWLER_ID: "autohub"
       CRAWLER_NAME: "autohub"
@@ -35,6 +49,13 @@ services:
   onbid_daily:
     image: crawler:latest
     container_name: crawler-onbid-daily
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       CRAWLER_ID: "onbid_daily"
       CRAWLER_NAME: "onbid_daily"
@@ -51,6 +72,13 @@ services:
   automart:
     image: crawler:latest
     container_name: crawler-automart
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       CRAWLER_ID: "automart"
       CRAWLER_NAME: "automart"


### PR DESCRIPTION
## Summary
- implement `/health` endpoint in run.py
- expose port 8080 and add curl-based health checks for each crawler service
- document built-in health monitoring setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac6d1762a4832aa32a532d9a6686ec